### PR TITLE
fix(getInitialProps): Rm getInitialProps from _app to reduce load tim…

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -43,10 +43,3 @@ const MyApp = ({
 };
 
 export default MyApp;
-
-MyApp.getInitialProps = async () => {
-  const chainOptions = await getChainOptions();
-  return {
-    ...chainOptions,
-  };
-};


### PR DESCRIPTION
…e, we can get the props after load

For your info 

getInitialProps is a legacy API on NEXT, thats one booboo but also we dont need it at all right now as we query the info after load

In future if you want to improve load time you can use getServerSideProps or another available helper wiht similar name (theres2) to load some initial data from an API or something 

This removed code should improve time. 
On netlify after merging you should clear cache and redeploy, seek me for guidance on how if needed. 